### PR TITLE
Increase session length to 4 hours by default

### DIFF
--- a/web/.platform.app.yaml
+++ b/web/.platform.app.yaml
@@ -79,3 +79,5 @@ variables:
   php:
       session.cookie_httponly: on
       session.cookie_secure: on
+      session.cookie_lifetime: 14400
+      session.gc_maxlifetime: 14400


### PR DESCRIPTION
@joindin/leadership-team Did I miss any other places to set this timeout?


Resolves https://github.com/joindin/joindin-web2/issues/834